### PR TITLE
add StartupWMClass in the linux .desktop entry

### DIFF
--- a/linux/classipod.desktop
+++ b/linux/classipod.desktop
@@ -6,3 +6,4 @@ Icon=/usr/share/icons/classipod/classipod.png
 Terminal=false
 Type=Application
 Categories=AudioVideo;Audio;Player;Music;
+StartupWMClass=classipod

--- a/snap/gui/classipod.desktop
+++ b/snap/gui/classipod.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Audio;Player;Music;
 Keywords=music;player;audio;ipod;local;songs;offline;
+StartupWMClass=classipod


### PR DESCRIPTION
in simple terms, `StartupWMClass` is used in Linux desktops to know what window is associated with an application. This allows the application to properly pinned and its icon can be changed

All Submissions:

[✓] Have you followed the guidelines in our Contributing document?
[✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/adeeteya/Classipod/pulls) for the same update/change?

### New Feature Submissions:

1. [✕] Does your submission work for all the platforms (android,windows and web app)?
2. [✕] Have you lint your code locally before submission? (using flutter_lints package)

### Changes to Core Features:

[✓ ] Have you added an explanation of what your changes do and why you'd like me to include them?
[✕ ] Have you added the feature to the features column of ```readme.md``` ?