### PR TITLE
🐛 fix music rescan getting stuck

### DIFF
--- a/lib/features/settings/controller/settings_preferences_controller.dart
+++ b/lib/features/settings/controller/settings_preferences_controller.dart
@@ -6,7 +6,9 @@ import 'package:classipod/core/constants/constants.dart';
 import 'package:classipod/core/extensions/build_context_extensions.dart';
 import 'package:classipod/core/models/music_metadata.dart';
 import 'package:classipod/core/navigation/routes.dart';
+import 'package:classipod/core/providers/filtered_audio_files_provider.dart';
 import 'package:classipod/core/services/audio_player_service.dart';
+import 'package:classipod/features/app_startup/controllers/splash_controller.dart';
 import 'package:classipod/features/music/playlist/models/playlist_model.dart';
 import 'package:classipod/features/settings/models/app_theme.dart';
 import 'package:classipod/features/settings/models/click_wheel_sensitivity.dart';
@@ -313,6 +315,11 @@ class SettingsPreferencesControllerNotifier
     if (clearPlaylists) {
       await Hive.box<PlaylistModel>(Constants.playlistBoxName).clear();
     }
+
+    // Clear cached scan and startup state before reopening the splash screen.
+    ref.invalidate(filteredAudioFilesProvider);
+    ref.invalidate(splashControllerProvider);
+
     ref.read(routerProvider).goNamed(Routes.splash.name);
   }
 


### PR DESCRIPTION
## Submission checklist

- [x] I have followed the guidelines in the contributing document.
- [x] I checked that there are no other open pull requests for the same change.
- [x] I linted and analyzed the code locally.

### New feature submissions

Not applicable, this is a bug fix.

### Changes to core features

- [x] I have explained what the change does and why it should be included.
- [x] README feature-list update is not applicable because this adds no new feature.

## Summary

Related to #98 and other reports of music scanning problems.

Fixes the in-app **Rescan Music Files** flow becoming stuck on the
scanning screen.

The rescan cleared the stored music metadata, but the cached filtered
library and completed splash startup state were reused. Invalidating
both providers before reopening the splash screen makes an in-app
rescan perform the same initialization as a fresh application launch.

## Root cause

`rescanMusicFiles()` cleared the Hive metadata box and navigated to the
splash screen, but `filteredAudioFilesProvider` still contained its
previous completed value.

The splash startup provider had also already completed and was not
automatically restarted when navigating back to the splash route.

This explains why force-closing and reopening the app fixed the problem:
restarting the process disposed the cached Riverpod state.

## Changes

- Invalidate `filteredAudioFilesProvider` after clearing the stored
  music metadata.
- Invalidate `splashControllerProvider` before reopening the splash
  screen.
- Keep the existing fresh-install and permission behavior unchanged.

## Clarification about the 999 songs limit report/issue

While investigating this, I found that the current scanner can load more
than 999 songs. My test library successfully reached past 1,300 songs.

The reproducible problem was stale state during an in-app rescan rather
than a hard 999 songs limit in the Android music query.

## Why I worked on this

I use Classipod personally and regularly add music to my phone, I love music ❤️.

Before this fix, refreshing my library required clearing the app data,
granting storage permission again, skipping the tutorial, and waiting
for another fresh scan. This fix makes the existing rescan option behave
as expected without repeating that annoying setup.

## Testing

Tested on:

- Samsung Galaxy S22
- Android 16
- Production release APK built from this branch

Manual regression tests:

- Reproduced the stuck rescan behavior in the current official release.
- Confirmed that force-closing and reopening the official release
  completed the scan.
- Started with a library of approximately 940 songs.
- Added more music and used the fixed in-app rescan.
- Confirmed the updated library contained 1,314 songs.
- Added another song and confirmed a subsequent rescan detected it.
- Repeated the rescan without adding music and confirmed it returned to
  the complete main UI.
- Cleared the app data and confirmed fresh-install scanning still
  worked.
- Confirmed normal playback and navigation still worked.
- Even tested the exclude directories function and it works properly.

Checks run:

- `fvm flutter analyze --suppress-analytics`
- `fvm flutter test --no-pub --coverage --suppress-analytics`
- `fvm flutter test --no-pub test/widget_tests/app_startup_widget_test.dart test/widget_tests/go_router_test.dart`
- Production release Android APK build

## Scope

This PR intentionally does not add:

- Scan progress notifications
- Background scanning
- User-selected scan folders
- Changes to the Android music-query plugin

Those can be handled separately without expanding this bug-fix PR.

Thank you, hope this will make the users happy, would be lovely to be in the next release.